### PR TITLE
修复wireshark版本大于4.4时（lua version=5.4)lua脚本加载失败的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ There is the Video and Audio plugin for Wireshark
 
 Wireshark的音视频插件
 
+# 更新说明
+当前版本自测支持WireShark 4.4.0版本(lua5.4)
 
 # 文件说明
 rtp_h264_export.lua用于解析RTP包中的H264编码数据。本插件参考作者HuangQiangxiong(qiangxiong.huang@gmail.com)所作的H264解析插件，并进行了修改。

--- a/README.md
+++ b/README.md
@@ -4,27 +4,29 @@ There is the Video and Audio plugin for Wireshark
 Wireshark的音视频插件
 
 # 更新说明
-当前版本自测支持WireShark 4.4.0版本(lua5.4)
+当前版本自测支持WireShark 4.4.0+版本(lua5.4)
 
 # 文件说明
-rtp_h264_export.lua用于解析RTP包中的H264编码数据。本插件参考作者HuangQiangxiong(qiangxiong.huang@gmail.com)所作的H264解析插件，并进行了修改。
 
-rtp_h265_export.lua用于解析RTP包中的H265编码数据，并提取裸数据到码流文件中。
+> [!IMPORTANT]
+> *rtp_ps_no_assemble.lua*不能与*rtp_ps_assemble.lua*同时使用。
+> 
+*rtp_h264_export.lua*用于解析RTP包中的H264编码数据。本插件参考作者HuangQiangxiong(qiangxiong.huang@gmail.com)所作的H264解析插件，并进行了修改。
 
-rtp_ps_no_assemble.lua为早期的不组合ps，直接对每一个RTP数据进行解析。
-rtp_ps_assemble.lua通过把ps流组装完整后解析数据。
+*rtp_h265_export.lua*用于解析RTP包中的H265编码数据，并提取裸数据到码流文件中。
 
-rtp_ps_no_assemble不能与rtp_ps_assemble同时使用。
+*rtp_ps_no_assemble.lua*为早期的不组合ps，直接对每一个RTP数据进行解析。
 
-rtp_ps_export.lua插件用于实现对PS媒体流进行解析及导出ps裸流到文件中。同时也可以直接使用ps中的相应媒体协议导出媒体数据流。
+*rtp_ps_assemble.lua*通过把ps流组装完整后解析数据。
 
-rtp_pcma_export.lua、rtp_pcmu_export.lua、rtp_silk_export.lua、rtp_g729_export.lua、rtp_amr_export.lua等插件用于对RTP流中的相应格式的音频流进行解析并导出成文件。
+*rtp_ps_export.lua*插件用于实现对PS媒体流进行解析及导出ps裸流到文件中。同时也可以直接使用ps中的相应媒体协议导出媒体数据流。
+
+*rtp_pcma_export.lua*、*rtp_pcmu_export.lua*、*rtp_silk_export.lua*、*rtp_g729_export.lua*、*rtp_amr_export.lua*等插件用于对RTP流中的相应格式的音频流进行解析并导出成文件。
 
 
 # 加载插件方法
 
 在Wireshark的About(关于)页面Folders(文件夹)目录下Personal plugins(个人Lua插件)对应的目录中存放lua插件文件。本方法中的插件只能存放在该的目录下，不能识别该目录下的子目录。
-
 
 # 插件中直接播放媒体
 

--- a/rtp_amr_export.lua
+++ b/rtp_amr_export.lua
@@ -33,7 +33,23 @@ do
     -- 导出数据到文件部分
     local version_str = string.match(_VERSION, "%d+[.]%d*")
     local version_num = version_str and tonumber(version_str) or 5.1
-    local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+    -- lua>=5.4 直接使用位操作
+	-- 使用bit32进行位操作
+	if (version_num >= 5.4) then
+	   local function band(a,b)
+		  return(a&b)
+	   end
+
+	   local function bor(a,b)
+		  return(a|b)
+	   end
+
+	   local function lshift(a,b)
+		  return(a<<b)
+	   end
+	else
+	   local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+	end
 
     -- for geting data (the field's value is type of ByteArray)
     local f_data = Field.new("amr")

--- a/rtp_amr_export.lua
+++ b/rtp_amr_export.lua
@@ -34,16 +34,16 @@ do
     local version_str = string.match(_VERSION, "%d+[.]%d*")
     local version_num = version_str and tonumber(version_str) or 5.1
     -- lua>=5.4 直接使用位操作
-	-- 使用bit32进行位操作
+    -- 使用bit32进行位操作
 	if (version_num >= 5.4) then
 	   local function band(a,b)
 		  return(a&b)
 	   end
-
+	
 	   local function bor(a,b)
 		  return(a|b)
 	   end
-
+	
 	   local function lshift(a,b)
 		  return(a<<b)
 	   end

--- a/rtp_h264_export.lua
+++ b/rtp_h264_export.lua
@@ -9,7 +9,23 @@
 do
     local version_str = string.match(_VERSION, "%d+[.]%d*")
     local version_num = version_str and tonumber(version_str) or 5.1
-    local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+    -- lua>=5.4 直接使用位操作
+	-- 使用bit32进行位操作
+	if (version_num >= 5.4) then
+	   local function band(a,b)
+		  return(a&b)
+	   end
+
+	   local function bor(a,b)
+		  return(a|b)
+	   end
+
+	   local function lshift(a,b)
+		  return(a<<b)
+	   end
+	else
+	   local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+	end
 
     function string.starts(String,Start)
         return string.sub(String,1,string.len(Start))==Start

--- a/rtp_h265_export.lua
+++ b/rtp_h265_export.lua
@@ -10,7 +10,23 @@
 do
     local version_str = string.match(_VERSION, "%d+[.]%d*")
     local version_num = version_str and tonumber(version_str) or 5.1
-    local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+    -- lua>=5.4 直接使用位操作
+	-- 使用bit32进行位操作
+	if (version_num >= 5.4) then
+	   local function band(a,b)
+		  return(a&b)
+	   end
+
+	   local function bor(a,b)
+		  return(a|b)
+	   end
+
+	   local function lshift(a,b)
+		  return(a<<b)
+	   end
+	else
+	   local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+	end
 
     function string.starts(String,Start)
         return string.sub(String,1,string.len(Start))==Start

--- a/rtp_ps_assemble.lua
+++ b/rtp_ps_assemble.lua
@@ -5,7 +5,23 @@
 do
     local version_str = string.match(_VERSION, "%d+[.]%d*")
 	local version_num = version_str and tonumber(version_str) or 5.1
-    local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+    -- lua>=5.4 直接使用位操作
+	-- 使用bit32进行位操作
+	if (version_num >= 5.4) then
+	   local function band(a,b)
+		  return(a&b)
+	   end
+
+	   local function bor(a,b)
+		  return(a|b)
+	   end
+
+	   local function lshift(a,b)
+		  return(a<<b)
+	   end
+	else
+	   local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+	end
 
     local ps_stream_type_vals = {
         [0x0f] = "AAC",

--- a/rtp_ps_export.lua
+++ b/rtp_ps_export.lua
@@ -7,7 +7,23 @@
 do
     local version_str = string.match(_VERSION, "%d+[.]%d*")
     local version_num = version_str and tonumber(version_str) or 5.1
-    local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+    -- lua>=5.4 直接使用位操作
+	-- 使用bit32进行位操作
+	if (version_num >= 5.4) then
+	   local function band(a,b)
+		  return(a&b)
+	   end
+
+	   local function bor(a,b)
+		  return(a|b)
+	   end
+
+	   local function lshift(a,b)
+		  return(a<<b)
+	   end
+	else
+	   local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+	end
 
     function get_temp_path()
         local tmp = nil

--- a/rtp_ps_no_assemble.lua
+++ b/rtp_ps_no_assemble.lua
@@ -5,7 +5,23 @@
 do
     local version_str = string.match(_VERSION, "%d+[.]%d*")
 	local version_num = version_str and tonumber(version_str) or 5.1
-    local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+    -- lua>=5.4 直接使用位操作
+	-- 使用bit32进行位操作
+	if (version_num >= 5.4) then
+	   local function band(a,b)
+		  return(a&b)
+	   end
+
+	   local function bor(a,b)
+		  return(a|b)
+	   end
+
+	   local function lshift(a,b)
+		  return(a<<b)
+	   end
+	else
+	   local bit = (version_num >= 5.2) and require("bit32") or require("bit")
+	end
 
     local ps_stream_type_vals = {
         [0x0f] = "AAC",


### PR DESCRIPTION
修复wireshark版本大于4.4时（lua version=5.4)lua脚本加载失败的问题